### PR TITLE
Fix spelling mistake in `action.yml`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 ---
 name: infrabits/pipup
-description: Automatic update of `pip` dependancies
+description: Automatic update of `pip` dependencies
 
 secrets:
   github-access-token:


### PR DESCRIPTION
The Action's description as listed on the marketplace is spelt wrong 🙂